### PR TITLE
Updates to make commands pipeable #1.

### DIFF
--- a/AppVeyor/vsix.ps1
+++ b/AppVeyor/vsix.ps1
@@ -1,92 +1,102 @@
 # VSIX Module for AppVeyor by Mads Kristensen
+[cmdletbinding()]
+param()
 
 $vsixUploadEndpoint = "http://vsixgallery.com/api/upload"
 #$vsixUploadEndpoint = "http://localhost:7035/extension/uploadFile"
 
 function Vsix-PushArtifacts {
-
-    [CmdletBinding()]
+    [cmdletbinding()]
     param (
-        [Parameter(Position=0, Mandatory=0)]
+        [Parameter(Position=0, Mandatory=0,ValueFromPipeline=$true)]
         [string]$path = "./*.vsix",
 
         [switch]$publishToGallery
     ) 
+    process {
+        foreach($filePath in $path) {
+            $fileName = (Get-ChildItem $filePath -Recurse)[0] # Instead of taking the first, support multiple vsix files
 
-    $fileName = (Get-ChildItem $path -Recurse)[0] # Instead of taking the first, support multiple vsix files
+            if (Get-Command Update-AppveyorBuild -errorAction SilentlyContinue)
+            {
+                Write-Host ("Pushing artifact " + $fileName.Name + "...") -ForegroundColor Cyan -NoNewline
+                Push-AppveyorArtifact ($fileName.FullName) -FileName $fileName.Name
+                Write-Host "OK" -ForegroundColor Green
+            }
 
-    if (Get-Command Update-AppveyorBuild -errorAction SilentlyContinue)
-    {
-        Write-Host ("Pushing artifact " + $fileName.Name + "...") -ForegroundColor Cyan -NoNewline
-        Push-AppveyorArtifact $fileName.FullName -FileName $fileName.Name
-        Write-Host "OK" -ForegroundColor Green
-    }
-
-    if ($publishToGallery -and $fileName)
-    {
-        vsix-PublishToGallery $fileName.FullName
+            if ($publishToGallery -and $fileName)
+            {
+                Vsix-PublishToGallery $fileName.FullName
+            }
+        }
     }
 }
 
-function vsix-PublishToGallery{
-
-    [CmdletBinding()]
+function Vsix-PublishToGallery{
+    [cmdletbinding()]
     param (
-        [Parameter(Position=0, Mandatory=0)]
-        [string]$path = "./*.vsix"
+        [Parameter(Position=0, Mandatory=0,ValueFromPipeline=$true)]
+        [string[]]$path = "./*.vsix"
     ) 
+    foreach($filePath in $path){
+        if ($env:APPVEYOR_PULL_REQUEST_NUMBER){
+            return
+        }
 
-    if ($env:APPVEYOR_PULL_REQUEST_NUMBER){
-        return
-    }
+        $repo = ""
+        $issueTracker = ""
 
-    $repo = ""
-    $issueTracker = ""
+        if ($env:APPVEYOR_REPO_PROVIDER -contains "github"){
+            [Reflection.Assembly]::LoadWithPartialName("System.Web") | Out-Null
+            $repo = [System.Web.HttpUtility]::UrlEncode(("https://github.com/" + $env:APPVEYOR_REPO_NAME + "/"))
+            $issueTracker = [System.Web.HttpUtility]::UrlEncode(($repo + "issues/"))
+        }
 
-    if ($env:APPVEYOR_REPO_PROVIDER -contains "github"){
-        [Reflection.Assembly]::LoadWithPartialName("System.Web") | Out-Null
-        $repo = [System.Web.HttpUtility]::UrlEncode(("https://github.com/" + $env:APPVEYOR_REPO_NAME + "/"))
-        $issueTracker = [System.Web.HttpUtility]::UrlEncode(($repo + "issues/"))
-    }
+        'Publish to VSIX Gallery...' | Write-Host -ForegroundColor Cyan -NoNewline
 
-    Write-Host "Publish to VSIX Gallery..." -ForegroundColor Cyan -NoNewline
+        $fileName = (Get-ChildItem $filePath -Recurse)[0] # Instead of taking the first, support multiple vsix files
 
-    $fileName = (Get-ChildItem $path -Recurse)[0] # Instead of taking the first, support multiple vsix files
-
-    [string]$url = ($vsixUploadEndpoint + "?repo=" + $repo + "&issuetracker=" + $issueTracker)
-    [byte[]]$bytes = [System.IO.File]::ReadAllBytes($fileName)
+        [string]$url = ($vsixUploadEndpoint + "?repo=" + $repo + "&issuetracker=" + $issueTracker)
+        [byte[]]$bytes = [System.IO.File]::ReadAllBytes($fileName)
     
-    try {
-        $response = Invoke-WebRequest $url -Method Post -Body $bytes
-        Write-Host "OK" -ForegroundColor Green
-    } catch{
-        Write-Host "FAIL" -ForegroundColor Red
-        write-host $_.Exception.Response.Headers["x-error"]
+        try {
+            $response = Invoke-WebRequest $url -Method Post -Body $bytes
+            'OK' | Write-Host -ForegroundColor Green
+        }
+        catch{
+            'FAIL' | Write-Error
+            $_.Exception.Response.Headers["x-error"] | Write-Error
+        }
     }    
 }
 
 function Vsix-UpdateBuildVersion {
-
-    [CmdletBinding()]
+    [cmdletbinding()]
     param (
         [Parameter(Position=0, Mandatory=1)]
-        [Version]$version
+        [Version[]]$version,
+        [Parameter(Position=1,ValueFromPipeline=$true)]
+        $vsixFilePath
     ) 
+    process{
+        foreach($ver in $version) {
+            if (Get-Command Update-AppveyorBuild -errorAction SilentlyContinue)
+            {
+                Write-Host "Updating AppVeyor build version..." -ForegroundColor Cyan -NoNewline
+                Update-AppveyorBuild -Version $ver | Out-Null
+                $ver | Write-Host -ForegroundColor Green
+            }
 
-    if (Get-Command Update-AppveyorBuild -errorAction SilentlyContinue)
-    {
-        Write-Host "Updating AppVeyor build version..." -ForegroundColor Cyan -NoNewline
-        Update-AppveyorBuild -Version $version
-        Write-Host $version -ForegroundColor Green
+            $vsixFilePath
+        }
     }
 }
 
 function Vsix-IncrementVsixVersion {
-
-    [CmdletBinding()]
+    [cmdletbinding()]
     param (
-        [Parameter(Position=0, Mandatory=0)]
-        [string]$manifestFilePath = ".\source.extension.vsixmanifest",
+        [Parameter(Position=0, Mandatory=0,ValueFromPipeline=$true)]
+        [string[]]$manifestFilePath = ".\source.extension.vsixmanifest",
 
         [Parameter(Position=1, Mandatory=0)]
         [int]$buildNumber = $env:APPVEYOR_BUILD_NUMBER,
@@ -97,33 +107,40 @@ function Vsix-IncrementVsixVersion {
 
         [switch]$updateBuildVersion
     )
+    process {
+        foreach($manifestFile in $manifestFilePath)
+        {
+            "Incrementing VSIX version..." | Write-Host  -ForegroundColor Cyan -NoNewline
 
-    Write-Host "Incrementing VSIX version..."  -ForegroundColor Cyan -NoNewline
+            $vsixManifest = (Get-ChildItem $manifestFile -Recurse)[0] # Instead of taking the first, support multiple vsixmanifest files
+            [xml]$vsixXml = Get-Content $vsixManifest
 
-    $vsixManifest = (Get-ChildItem $manifestFilePath -Recurse)[0] # Instead of taking the first, support multiple vsixmanifest files
-    [xml]$vsixXml = Get-Content $vsixManifest
+            $ns = New-Object System.Xml.XmlNamespaceManager $vsixXml.NameTable
+            $ns.AddNamespace("ns", $vsixXml.DocumentElement.NamespaceURI) | Out-Null
 
-    $ns = New-Object System.Xml.XmlNamespaceManager $vsixXml.NameTable
-    $ns.AddNamespace("ns", $vsixXml.DocumentElement.NamespaceURI)
+            $attrVersion = $vsixXml.SelectSingleNode("//ns:Identity", $ns).Attributes["Version"]
 
-    $attrVersion = $vsixXml.SelectSingleNode("//ns:Identity", $ns).Attributes["Version"]
+            [Version]$version = $attrVersion.Value;
 
-    [Version]$version = $attrVersion.Value;
-
-    if ($versionType -eq "build"){
-        $version = New-Object Version ([int]$version.Major),([int]$version.Minor),$buildNumber
-    }
-    elseif ($versionType -eq "revision"){
-        $version = New-Object Version ([int]$version.Major),([int]$version.Minor),([System.Math]::Max([int]$version.Build, 0)),$buildNumber
-    }
+            if ($versionType -eq "build"){
+                $version = New-Object Version ([int]$version.Major),([int]$version.Minor),$buildNumber
+            }
+            elseif ($versionType -eq "revision"){
+                $version = New-Object Version ([int]$version.Major),([int]$version.Minor),([System.Math]::Max([int]$version.Build, 0)),$buildNumber
+            }
         
-    $attrVersion.Value = $version
-    $vsixXml.Save($vsixManifest)
+            $attrVersion.Value = $version
+            $vsixXml.Save($vsixManifest) | Out-Null
 
-    Write-Host $version.ToString() -ForegroundColor Green
+            $version.ToString() | Write-Host -ForegroundColor Green
 
-    if ($updateBuildVersion -and $env:APPVEYOR_BUILD_VERSION -ne $version.ToString())
-    {
-        Vsix-UpdateBuildVersion $version
+            if ($updateBuildVersion -and $env:APPVEYOR_BUILD_VERSION -ne $version.ToString())
+            {
+                Vsix-UpdateBuildVersion $version | Out-Null
+            }
+
+            # return manifestFile for the pipeline
+            $manifestFile
+        }
     }
 }


### PR DESCRIPTION
OK I have made changes so that you can pipe these commands.

You should now be able to do things like.

``` powershell
> Vsix-IncrementVsixVersion | Vsix-UpdateBuildVersion

> '.\source.extension.vsixmanifest' | Vsix-IncrementVsixVersion |
> Vsix-UpdateBuildVersion

>@('.\source.extension.vsixmanifest','.\source2.extension.vsixmanifest') |
>Vsix-IncrementVsixVersion | Vsix-UpdateBuildVersion -version 1.1
```

Roughly what I did was add a process block and the ValueFromPipeline on
the parameter for the vsix file path. To support pipelining the functions
need to return values to the pipeline so in some cases you'll see that
I've added a statement that outputs the filename to the pipleine. When
pipelining you should be careful with returing any extra results so I
added a couple of | Out-Null to the end of some calls.

I also changed some lines from Write-Host 'sample' to 'sample' |
Write-Host that is my preferred way to call Write-Host and I recommend
that for you as well.

I couldn't test the Vsix-PublishToGallery locally so try it in AppVeyor
and let me know if you have issues. If you get serious about this and want
others to use it I'd recommend adding pester test cases which mock the
Appveyor/publish calls so that changes can be tested locally. I can help
you get started with that if you want.
- Usage of `{` is not consistent
- Instead of " use ' by default unless you have expressions you want to
  expand
- Instead of `'error' | Write-Host -ForegroundColor Red use 'error' |
  Write-Error`
- use lowercase in [cmdletbinding()]
- Vsix-PushArtifact can be improved the way it's authored it will hide errors. For ex if
- publishToGallery is passed but there is no value for $filename
- This script is specifically targeted at AppVeyor so Write-Host may be OK, but I'd recommend trying to avoid that in general. Instead use Write-Verbose/Write-Output/Write-Warning/Write-Error
- If this is designed to be used with Import-Module then you should rename this file to be end in .psm1 so that it's obvious how to consume it
