### PR TITLE
Send correct issue tracker URL on vsixgallery.com

### DIFF
--- a/AppVeyor/vsix.ps1
+++ b/AppVeyor/vsix.ps1
@@ -48,8 +48,8 @@ function Vsix-PublishToGallery{
 
         if ($env:APPVEYOR_REPO_PROVIDER -contains "github"){
             [Reflection.Assembly]::LoadWithPartialName("System.Web") | Out-Null
-            $repo = [System.Web.HttpUtility]::UrlEncode(("https://github.com/" + $env:APPVEYOR_REPO_NAME + "/"))
-            $issueTracker = [System.Web.HttpUtility]::UrlEncode(($repo + "issues/"))
+            $repo = "https://github.com/" + [System.Web.HttpUtility]::UrlEncode($env:APPVEYOR_REPO_NAME) + "/"
+            $issueTracker = $repo + "issues/"
         }
 
         'Publish to VSIX Gallery...' | Write-Host -ForegroundColor Cyan -NoNewline


### PR DESCRIPTION
The "Issue Tracker" links of extensions published to vsixgallery.com using this script are currently wrong because of the URL escaping, e.g.: http://vsixgallery.com/extension/5fb7364d-2e8c-44a4-95eb-2a382e30fec9/

I've tested this PR on https://github.com/SonarSource/sonarlint-vs/blob/master/appveyor.yml, for which the "Issue Tracker" link is now correct from the "SonarLint for Visual Studio" page on http://vsixgallery.com

BTW there seems to be another issue (unrelated to this PR) with direct links to extensions:
- http://vsixgallery.com/extension/5fb7364d-2e8c-44a4-95eb-2a382e30fec9/ works fine
- http://vsixgallery.com/extension/SonarLint.8c442ec8-0208-4840-b83f-acd24f41acf7/ shows up empty
- http://vsixgallery.com/extension/NR6Pack.Refactorings.Vsix..cd27e59b-5c56-4238-8931-c9bb745a7a7f/ also shows up empty
