### PR TITLE
Improve support for extensions hosted on bitbucket

### DIFF
--- a/AppVeyor/vsix.ps1
+++ b/AppVeyor/vsix.ps1
@@ -53,6 +53,10 @@ function Vsix-PublishToGallery{
             [Reflection.Assembly]::LoadWithPartialName("System.Web") | Out-Null
             $repo = [System.Web.HttpUtility]::UrlEncode(("https://github.com/" + $env:APPVEYOR_REPO_NAME + "/"))
             $issueTracker = [System.Web.HttpUtility]::UrlEncode(($repo + "issues/"))
+        } elseif ($env:APPVEYOR_REPO_PROVIDER -contains "bitbucket"){
+            [Reflection.Assembly]::LoadWithPartialName("System.Web") | Out-Null
+            $repo = [System.Web.HttpUtility]::UrlEncode(("https://bitbucket.org/" + $env:APPVEYOR_REPO_NAME + "/"))
+            $issueTracker = [System.Web.HttpUtility]::UrlEncode(($repo + "issues/"))
         }
 
         'Publish to VSIX Gallery...' | Write-Host -ForegroundColor Cyan -NoNewline


### PR DESCRIPTION
Provide visxgallery with repo and issue tracker links to extensions hosted on bitbucket.org.
This can later be used e.g. to display the README.md file.
