### PR TITLE
Vsix-PublishToGallery failure as IE never launched

### DIFF
--- a/AppVeyor/vsix.ps1
+++ b/AppVeyor/vsix.ps1
@@ -69,7 +69,7 @@ function Vsix-PublishToGallery{
             [byte[]]$bytes = [System.IO.File]::ReadAllBytes($vsixFile)
 
             try {
-                $response = Invoke-WebRequest $url -Method Post -Body $bytes
+                $response = Invoke-WebRequest $url -Method Post -Body $bytes -UseBasicParsing
                 'OK' | Write-Host -ForegroundColor Green
             }
             catch{


### PR DESCRIPTION
Vsix-PublishToGallery was failing with:

```
Cannot index into a null array.
At line:77 char:17
+ ...                $_.Exception.Response.Headers["x-error"] | Write-Error
```

Turns out the actual error is:

```
System.NotSupportedException: The response content cannot be parsed because the Internet Explorer engine is not available, or Internet Explorer's first-launch configuration is not complete. Specify the UseBasicParsing  parameter and try again.
```
