### PR TITLE
Improve Chocolatey packages

### DIFF
--- a/AppVeyor/vsix.ps1
+++ b/AppVeyor/vsix.ps1
@@ -346,7 +346,7 @@ function Vsix-CreateChocolatyPackage {
 
             $sb = New-Object System.Text.StringBuilder
             $sb.AppendLine("`$name = `'" + $displayName + "`'") | Out-Null
-            $sb.AppendLine("`$url = `'" + "http://vsixgallery.com/extensions/" + $id + "/" + $displayName + ".vsix`'") | Out-Null
+            $sb.AppendLine("`$url = `'" + "https://vsixgallery.azurewebsites.net/extensions/" + $id + "/" + $displayName + ".vsix`'") | Out-Null
             $sb.AppendLine("Install-ChocolateyVsixPackage `$name `$url") | Out-Null
 
             


### PR DESCRIPTION
1. Modern versions of Chocolatey require packages to use checksums and/or HTTPS for security reasons, otherwise the package will not be installed under default Chocolatey configuration.
2. `<packageSourceUrl>` is added so that users browsing the Chocolatey gallery can easily locate the correct repository (you have quite a few of them).