### PR TITLE
Fix vsix.ps1

### DIFF
--- a/AppVeyor/vsix.ps1
+++ b/AppVeyor/vsix.ps1
@@ -65,7 +65,7 @@ function Vsix-PublishToGallery{
         $repoUrl = Vsix-GetRepoUrl
         if ($baseRepoUrl -ne "") {
             [Reflection.Assembly]::LoadWithPartialName("System.Web") | Out-Null
-            $repo = System.Web.HttpUtility]::UrlEncode($repoUrl)
+            $repo = [System.Web.HttpUtility]::UrlEncode($repoUrl)
             $issueTracker = [System.Web.HttpUtility]::UrlEncode(($repo + "issues/"))
         }
 


### PR DESCRIPTION
A day ago, my CI builds started to fail with the following error.  This fixes that.

```
2017-05-11T20:43:59.4143330Z ##[error]Vsix-PublishToGallery : The term 'System.Web.HttpUtility]::UrlEncode' is not recognized as the name of a cmdlet, 
function, script file, or operable program. Check the spelling of the name, or if a path was included, verify that the 
path is correct and try again.
At E:\A\_work\80\s\build\postbuild.ps1:178 char:5
+     Vsix-PublishToGallery -path $vsix
+     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```