### PR TITLE
Fix issueTracker url

### DIFF
--- a/AppVeyor/vsix.ps1
+++ b/AppVeyor/vsix.ps1
@@ -66,7 +66,7 @@ function Vsix-PublishToGallery{
         if ($baseRepoUrl -ne "") {
             [Reflection.Assembly]::LoadWithPartialName("System.Web") | Out-Null
             $repo = [System.Web.HttpUtility]::UrlEncode($repoUrl)
-            $issueTracker = [System.Web.HttpUtility]::UrlEncode(($repo + "issues/"))
+            $issueTracker = [System.Web.HttpUtility]::UrlEncode(($repoUrl + "issues/"))
         }
 
         'Publish to VSIX Gallery...' | Write-Host -ForegroundColor Cyan -NoNewline


### PR DESCRIPTION
This _(hopefully)_ fixes the issue tracker url which does not work on the extension page in the vsix gallery http://vsixgallery.com/extension/763d21f2-0b6e-49d1-ac3c-bd3a74e78566/